### PR TITLE
Update dependencies and fix test compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
   <properties>
     <java.version>21</java.version>
     <spring-boot.version>3.5.0</spring-boot.version>
+    <maven.version>3.6.3</maven.version>
   </properties>
 
   <dependencyManagement>
@@ -104,11 +105,33 @@
 
   <build>
     <plugins>
+      <!-- Maven Enforcer Plugin -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.4.1</version>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>${maven.version}</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- JaCoCo -->
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.11</version>
+        <version>0.8.13</version>
         <executions>
           <execution>
             <id>prepare-agent</id>
@@ -138,7 +161,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.11.0</version>
+        <version>3.14.0</version>
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
@@ -172,7 +195,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.5</version>
+        <version>3.5.3</version>
         <configuration>
           <useModulePath>false</useModulePath>
         </configuration>

--- a/src/test/java/com/github/trcjr/oomlet/dto/CpuBurnResponseTest.java
+++ b/src/test/java/com/github/trcjr/oomlet/dto/CpuBurnResponseTest.java
@@ -29,7 +29,10 @@ class CpuBurnResponseTest {
 
     @Test
     void testUnusedConstructorForCoverage() {
-        CpuBurnResponse response = new CpuBurnResponse(1000L, 2, 500L, 1);
+        CpuBurnResponse response = new CpuBurnResponse(1000L, 2, "Test");
         assertNotNull(response);
+        assertEquals(1000L, response.getRequestedMillis());
+        assertEquals(2, response.getRequestedThreads());
+        assertEquals("Test", response.getStatus());
     }
 }


### PR DESCRIPTION
## Summary

This PR updates dependencies to their latest stable versions and fixes test compatibility issues.

## Changes

### Dependency Updates
- **JaCoCo**: 0.8.11 → 0.8.13 (fixes Java 24 compatibility)
- **Maven Compiler Plugin**: 3.11.0 → 3.14.0
- **Maven Surefire Plugin**: 3.2.5 → 3.5.3
- **Maven Enforcer Plugin**: Added 3.4.1 with minimum Maven version 3.6.3

### Bug Fixes
- Fixed CpuBurnResponseTest constructor call to match updated DTO
- Resolved Java 24 compatibility issues with JaCoCo

### Test Results
- ✅ All 67 tests now pass successfully
- ✅ Build completes without errors
- ✅ Pre-commit hooks pass

## Files Changed
- `pom.xml` - Updated plugin versions and added enforcer
- `src/test/java/com/github/trcjr/oomlet/dto/CpuBurnResponseTest.java` - Fixed constructor call

## Testing
- [x] All tests pass locally
- [x] Build completes successfully
- [x] No breaking changes introduced 